### PR TITLE
docs(readme): remove executor version in JinaHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use the prebuilt images from JinaHub in your python codes,
 from jina import Flow
 	
 f = Flow().add(
-        uses='jinahub+docker://CLIPImageEncoder:v1',
+        uses='jinahub+docker://CLIPImageEncoder',
         volumes='/your_home_folder/.cache/clip:/root/.cache/clip')
 ```
 
@@ -33,7 +33,7 @@ or in the `.yml` config.
 jtype: Flow
 pods:
   - name: encoder
-    uses: 'jinahub+docker://CLIPImageEncoder:v1'
+    uses: 'jinahub+docker://CLIPImageEncoder'
     volumes: '/your_home_folder/.cache/clip:/root/.cache/clip'
 ```
 
@@ -82,7 +82,7 @@ pods:
 
 
 ```python
-f = Flow().add(uses='jinahub+docker://CLIPImageEncoder:v0',
+f = Flow().add(uses='jinahub+docker://CLIPImageEncoder',
                volumes='/Users/nanwang/.cache/clip:/root/.cache/clip')
 
 


### PR DESCRIPTION
Version shouldn't be exposed to users now.